### PR TITLE
Align stack buffer on 32 bytes

### DIFF
--- a/cbits/main.c
+++ b/cbits/main.c
@@ -79,7 +79,9 @@ int hw_simd_json_sm_main(
   }
 
   uint8_t buffer[W8_BUFFER_SIZE];
-  uint32_t phi_buffer[W8_BUFFER_SIZE];
+
+  uint32_t unaligned_phi_buffer[W8_BUFFER_SIZE + 32];
+  uint32_t * phi_buffer = (uint32_t*) ((void*)unaligned_phi_buffer + ((uintptr_t)unaligned_phi_buffer & (uintptr_t)0x10));
 
   uint8_t ibs_buffer[W8_BUFFER_SIZE];
   uint8_t ops_buffer[W8_BUFFER_SIZE];

--- a/cbits/simd-spliced.c
+++ b/cbits/simd-spliced.c
@@ -50,7 +50,10 @@ int hw_json_simd_main_spliced(
     exit(1);
   }
 
-  uint8_t buffer[W8_BUFFER_SIZE];
+  // align stack buffer on 32 bytes 
+  uint8_t unaligned_buffer[W8_BUFFER_SIZE + 32];
+  uint8_t * buffer = unaligned_buffer + ((uintptr_t)unaligned_buffer & (uintptr_t)0x10);
+  fprintf(stderr, "Buffer is at address %p of size %zu\n", buffer, (size_t) W8_BUFFER_SIZE);
 
   uint8_t *bits_of_d = malloc(W32_BUFFER_SIZE); memset(bits_of_d, 0, W32_BUFFER_SIZE);
   uint8_t *bits_of_a = malloc(W32_BUFFER_SIZE); memset(bits_of_a, 0, W32_BUFFER_SIZE);

--- a/cbits/simd-state-table.c
+++ b/cbits/simd-state-table.c
@@ -1,4 +1,5 @@
 #include "intrinsics.h"
+#include <stdint.h>
 
 __m256i hw_simd_json_transition_phi_wide_table[256] =
   { {0x0000000000010100, 0, 0x0000000000000000, 0}


### PR DESCRIPTION
Include stdint.h for uint32_t portability
Relates to issue #53 