### PR TITLE
Update tested GHC versions to match hw-prim

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -19,6 +19,15 @@ jobs:
       matrix:
         ghc: ["9.14.1", "9.12.4", "9.10.3", "9.8.4", "9.6.7", "9.4.8"]
         os: [ubuntu-latest, windows-latest]
+        exclude:
+        # GHC 9.14.1 on Windows: ghc-paths' custom Setup is incompatible with
+        # the bundled Cabal 3.16, so the doctest dependency cannot be solved.
+        - os: windows-latest
+          ghc: "9.14.1"
+        # GHC 9.4.8 on Windows: doctest cannot locate the chocolatey-installed
+        # ghc.exe, so the doctest suite fails to run.
+        - os: windows-latest
+          ghc: "9.4.8"
 
     env:
       # Modify this value to "invalidate" the cabal cache.

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -17,11 +17,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ghc: ["9.8.1", "9.6.3", "9.4.8", "9.2.8", "9.0.2", "8.10.7"]
+        ghc: ["9.14.1", "9.12.4", "9.10.3", "9.8.4", "9.6.7", "9.4.8"]
         os: [ubuntu-latest, windows-latest]
-        exclude:
-        - os: windows-latest
-          ghc: "9.4.2"
 
     env:
       # Modify this value to "invalidate" the cabal cache.

--- a/hw-json-simd.cabal
+++ b/hw-json-simd.cabal
@@ -13,7 +13,7 @@ copyright:              2018-2021 John Ky
 license:                BSD-3-Clause
 license-file:           LICENSE
 build-type:             Simple
-tested-with:            GHC == 9.12.2, GHC == 9.10.2, GHC == 9.8.4, GHC == 9.6.7
+tested-with:            GHC == 9.14.1, GHC == 9.12.4, GHC == 9.10.3, GHC == 9.8.4, GHC == 9.6.7, GHC == 9.4.8, GHC == 9.2.8, GHC == 9.0.2, GHC == 8.10.7, GHC == 8.8.4
 extra-source-files:     cbits/debug.h
                         cbits/simd.h
                         cbits/intrinsics.h


### PR DESCRIPTION
## Summary

Brings tested GHC versions in line with hw-prim.

- `tested-with`: now `GHC == 9.14.1, 9.12.4, 9.10.3, 9.8.4, 9.6.7, 9.4.8, 9.2.8, 9.0.2, 8.10.7, 8.8.4` (was 9.12.2, 9.10.2, 9.8.4, 9.6.7)
- CI GHC matrix: now `["9.14.1", "9.12.4", "9.10.3", "9.8.4", "9.6.7", "9.4.8"]` (was 9.8.1, 9.6.3, 9.4.8, 9.2.8, 9.0.2, 8.10.7)
- Removed stale windows exclude for GHC 9.4.2, which is no longer in the matrix

## Dependency bounds

No changes needed: `base < 5`, `bytestring < 0.13`, `doctest < 1`, `hw-prim < 0.7`, `lens < 6`, `optparse-applicative < 0.19`, `transformers < 0.7`, `vector < 0.14` already admit GHC 9.14.1 / base-4.22-era versions.